### PR TITLE
Remove solidity pragma floater

### DIFF
--- a/contracts/HumanDaoDistributor.sol
+++ b/contracts/HumanDaoDistributor.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.8.4;
+pragma solidity 0.8.4;
 
 // SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
version floaters shouldn't be used with production contracts as it can allow for opening of vulnerabilities that make okay with future versions of solidity