### PR TITLE
Update HumanDaoDistributor.sol

### DIFF
--- a/contracts/HumanDaoDistributor.sol
+++ b/contracts/HumanDaoDistributor.sol
@@ -20,9 +20,8 @@ contract HumanDaoDistributor is MerkleDistributor {
         return distributionAmount;
     }
 
-    function mintNft(address account_, uint256 tokenId_) internal override  returns (uint256) {
-        humanDAONFT.mint(account_, tokenId_);
-        return tokenId_;
+    function mintNft(address account_) internal {
+        humanDAONFT._mintNFT(account_);
     }
 
     function transferRemainingTokens(address _token) external onlyOwner {


### PR DESCRIPTION
corrected syntax for calling nft mint. function to call from contract is _mintNFT() and only needs an address.